### PR TITLE
And workflow which will automatically update the branch when dependabot creates a PR to update the AWS SDK

### DIFF
--- a/.github/workflows/build-with-new-aws-sdk.yml
+++ b/.github/workflows/build-with-new-aws-sdk.yml
@@ -1,0 +1,46 @@
+name: Build package with new AWS SDK
+
+on:
+  push:
+    branches:
+      - dependabot/npm_and_yarn/aws-sdk-*
+
+jobs:
+    check-dist-and-push-changes:
+      runs-on: ubuntu-latest
+
+      steps:
+        - uses: actions/checkout@v3
+
+        - name: Set Node.js 18.x
+          uses: actions/setup-node@v3.5.1
+          with:
+            node-version: 18.x
+
+        - name: Install dependencies
+          run: npm ci
+
+        - name: Rebuild the dist/ directory
+          run: |
+            npm run build
+            npm run package
+
+        - name: Compare the current and actual dist/ directories
+          run: |
+            if [ "$(git diff --ignore-space-at-eol dist/ | wc -l)" -gt "0" ]; then
+              echo "Detected changes after build"
+              echo "CHANGES_DETECTED=TRUE" >> $GITHUB_OUTPUT
+            else
+              echo "No changes detected"
+              echo "CHANGES_DETECTED=FALSE" >> $GITHUB_OUTPUT
+            fi
+          id: diff
+
+        - name: Push changes to GitHub
+          run: |
+              git config --global user.name 'crown-marketplace-ci'
+              git config --global user.email 'crown-marketplace-ci@users.noreply.github.com'
+              git add dist/
+              git commit -m 'Adding changes to dist/ due to update to AWS SDK'
+              git push
+          if: ${{ steps.diff.outputs.CHANGES_DETECTED == 'TRUE' }}

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set Node.js 18.x
         uses: actions/setup-node@v3.5.1


### PR DESCRIPTION
When dependabot updates the AWS SDK package, the PR fails because the `dist/` changes.
This is because AWS is core dependency so it is built as part of the package.

The workflow I've created will detect if a AWS SDK update has happened and then update the dist accordingly